### PR TITLE
Fix copy_from_slice panic in read_blocking because of different lengths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ impl<T: Clone + Copy> RbProducer<T> for Producer<T> {
         } else {
             let d = buf_len - wr_pos;
             buf[wr_pos..].copy_from_slice(&data[..d]);
-            buf[..(cnt - d)].copy_from_slice(&data[d..]);
+            buf[..(cnt - d)].copy_from_slice(&data[d..cnt]);
         }
         self.inspector.write_pos.store(
             (wr_pos + cnt) % buf_len,
@@ -312,7 +312,7 @@ impl<T: Clone + Copy> RbProducer<T> for Producer<T> {
         } else {
             let d = buf_len - wr_pos;
             buf[wr_pos..].copy_from_slice(&data[..d]);
-            buf[..(cnt - d)].copy_from_slice(&data[d..]);
+            buf[..(cnt - d)].copy_from_slice(&data[d..cnt]);
         }
         self.inspector.write_pos.store(
             (wr_pos + cnt) % buf_len,
@@ -391,7 +391,7 @@ impl<T: Clone + Copy> RbConsumer<T> for Consumer<T> {
         } else {
             let d = buf_len - re_pos;
             data[..d].copy_from_slice(&buf[re_pos..]);
-            data[d..].copy_from_slice(&buf[..(cnt - d)]);
+            data[d..cnt].copy_from_slice(&buf[..(cnt - d)]);
         }
 
         // TODO: Notify all? empty->slots_free
@@ -422,7 +422,7 @@ impl<T: Clone + Copy> RbConsumer<T> for Consumer<T> {
         } else {
             let d = buf_len - re_pos;
             data[..d].copy_from_slice(&buf[re_pos..]);
-            data[d..].copy_from_slice(&buf[..(cnt - d)]);
+            data[d..cnt].copy_from_slice(&buf[..(cnt - d)]);
         }
 
         self.inspector.read_pos.store(


### PR DESCRIPTION
When reading from the ring buffer I always quickly get a panic at https://github.com/klingtnet/rb/blob/master/src/lib.rs#L425

```
thread '<unnamed>' panicked at 'destination and source slices have different lengths', /checkout/src/libcore/slice/mod.rs:669:8
```

We don't always write to the end of `data` but rather we write `cnt` bytes, which may be less than `data.len()`
