### PR TITLE
Update dependencies - compatible with latest rand crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ readme = "README.md"
 [dependencies]
 
 [dev-dependencies]
-rand_xorshift = "0.1.1"
-rand_core = "0.4.0"
+rand_xorshift = "0.2.0"
+rand_core = "0.5.1"


### PR DESCRIPTION
Bump the rand dependencies - all tests pass happily with no code changes.

Could also switch to a more lax version specification like `~0.5` or something, if we trust the rand libraries to stick to semver before `1.0.0`

EDIT: BTW before this patch two different version of rand_core seemed to be getting used.

```
C:\Users\Will\Documents\repos\rb>cargo test
    Updating crates.io index
   Compiling rand_core v0.4.2
   Compiling rb v0.3.2 (C:\Users\Will\Documents\repos\rb)
   Compiling rand_core v0.3.1
   Compiling rand_xorshift v0.1.1
    Finished dev [unoptimized + debuginfo] target(s) in 8.03s
```