### PR TITLE
Add `read_blocking_timeout` and `write_blocking_timeout` for cancellable blocking operations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub trait RbConsumer<T> {
     /// Returns `None` if the given slice has zero length.
     fn read_blocking(&self, data: &mut [T]) -> Option<usize>;
     /// Works analog to `read_blocking` but eventually returns if the specified timeout is reached.
-    /// the exact number is returned in the `Ok(Option)` value.
+    /// The exact number is returned in the `Ok(Option)` value.
     ///
     /// Returns `Ok(None)` if the given slice has zero length.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,7 @@ pub trait RbConsumer<T> {
     ///
     /// Returns `None` if the given slice has zero length.
     fn read_blocking(&self, data: &mut [T]) -> Option<usize>;
-    /// Works analog to `read` but blocks until it can read elements to fill
-    /// the given buffer slice or the specified timeout is reached.
-    /// The number of blocks read is not necessarily equal to the length of the given buffer slice,
+    /// Works analog to `read_blocking` but eventually returns if the specified timeout is reached.
     /// the exact number is returned in the `Ok(Option)` value.
     ///
     /// Returns `Ok(None)` if the given slice has zero length.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,7 @@ pub trait RbProducer<T> {
     ///
     /// Returns `None` if the given slice has zero length.
     fn write_blocking(&self, data: &[T]) -> Option<usize>;
-    /// Works analog to `write` but blocks until there are free slots in the ring buffer
-    /// or until the specified timeout is reached.
+    /// Works analog to `write_blocking` but eventually returns if the specified timeout is reached.
     /// The number of actual blocks written is returned in the `Ok(Option)` value.
     ///
     /// Returns `Ok(None)` if the given slice has zero length.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,7 @@
 extern crate rb;
 
+use std::time::Duration;
+
 use rb::{RbConsumer, RbInspector, RbProducer, SpscRb, RB};
 
 #[test]
@@ -160,6 +162,35 @@ fn test_read_write_wrap_blocking() {
     // Read data into a larger buffer, otherwise triggering a panic
     let mut out_data = vec![0; 3];
     consumer.read_blocking(&mut out_data).unwrap();
+    assert_eq!(rb.count(), 0);
+    assert_eq!(rb.slots_free(), 2);
+}
+
+#[test]
+fn test_read_write_timeout_wrap_blocking() {
+    const SIZE: usize = 2;
+    let rb = SpscRb::new(SIZE);
+    let (consumer, producer) = (rb.consumer(), rb.producer());
+    assert!(rb.is_empty());
+    let in_data = (0..SIZE).map(|i| i * 2).collect::<Vec<_>>();
+    // Fill the buffer
+    producer.write_blocking(&in_data).unwrap();
+    // Read half the data
+    let mut out_data = vec![0; 1];
+    consumer
+        .read_blocking_timeout(&mut out_data, Duration::from_millis(100))
+        .unwrap();
+    assert_eq!(rb.count(), 1);
+    assert_eq!(rb.slots_free(), 1);
+    // Write more data so that it wraps around
+    producer.write_blocking(&in_data).unwrap();
+    assert_eq!(rb.count(), 2);
+    assert_eq!(rb.slots_free(), 0);
+    // Read data into a larger buffer, otherwise triggering a panic
+    let mut out_data = vec![0; 3];
+    consumer
+        .read_blocking_timeout(&mut out_data, Duration::from_millis(100))
+        .unwrap();
     assert_eq!(rb.count(), 0);
     assert_eq!(rb.slots_free(), 2);
 }


### PR DESCRIPTION
I'm currently using `write_blocking` to write data into a ringbuffer that is consumed by an audio sink. However, there is a chance that the sink could error out during playback and stop processing samples. When that happens, `write_blocking` will block forever since nothing is pulling data out of the consumer anymore. This PR adds additional methods to cancel the blocking read or write after a specified timeout for scenarios like this.

Additionally, I made a few small changes to remove anonymous trait function parameters since those are [deprecated](https://doc.rust-lang.org/edition-guide/rust-2018/trait-fn-parameters.html).