### PR TITLE
Fix skip bug of consumer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ impl<T: Clone + Copy> RbConsumer<T> for Consumer<T> {
             let count = cmp::min(cnt, self.inspector.count());
             let prev_read_pos = self.inspector.read_pos.load(Ordering::Relaxed);
             self.inspector.read_pos.store(
-                (prev_read_pos + count) % self.inspector.capacity(),
+                (prev_read_pos + count) % self.inspector.size,
                 Ordering::Relaxed,
             );
             Ok(count)


### PR DESCRIPTION
The skipping function used the capacity of the inspector, instead of the size of the buffer, which is 1 greater.

This resulted in different behaviour between read() and the skip() and get() methods. In particular, one could not empty the buffer with the skip method.

A test was added to ensure the correctness.